### PR TITLE
Fix typo in notebook markdown

### DIFF
--- a/International Cricket prediction.ipynb
+++ b/International Cricket prediction.ipynb
@@ -449,7 +449,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we get rid of all the matches that didn't yeild a winner and create a separate column for the winner. This would later be used as label for classification"
+    "Now we get rid of all the matches that didn't yield a winner and create a separate column for the winner. This would later be used as label for classification"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- correct "yeild" typo in the notebook

## Testing
- `jq '.' 'International Cricket prediction.ipynb'`

------
https://chatgpt.com/codex/tasks/task_e_684cd94ab390832b9608d2997e3075ed